### PR TITLE
Improve `<Banner>` accessibility

### DIFF
--- a/components/Banner.js
+++ b/components/Banner.js
@@ -196,19 +196,21 @@ const Banner = () => {
   const [isOpen, setIsOpen] = useState(currentWidth <= RESIZE_BREAKPOINT)
 
   const close = () => {
-    const focusedElement = document.querySelector('[role=banner] *:focus')
+    if (currentWidth <= RESIZE_BREAKPOINT) {
+      const focusedElement = document.querySelector('[role=banner] *:focus')
 
-    if (focusedElement) {
-      focusedElement.blur()
+      if (focusedElement) {
+        focusedElement.blur()
+      }
+
+      setIsOpen(false)
     }
-
-    setIsOpen(false)
   }
 
   const updateOpenStateFromWindowSize = () => {
-    if (isOpen && (currentWidth <= RESIZE_BREAKPOINT)) {
+    if (isOpen) {
       close()
-    } else {
+    } else if (!isOpen) {
       setIsOpen(true)
     }
   }
@@ -242,7 +244,10 @@ const Banner = () => {
         onChange={({ target: { checked } }) => setIsOpen(checked)}
         type="checkbox" />
 
-      <header role="banner">
+      <header
+        aria-expanded={isOpen}
+        hidden={isOpen}
+        role="banner">
         {/* eslint-disable jsx-a11y/tabindex-no-positive,jsx-a11y/no-noninteractive-element-to-interactive-role */}
         <label
           aria-label={`${isOpen ? 'Collapse' : 'Expand'} Menu`}
@@ -277,7 +282,6 @@ const Banner = () => {
           claims={claims}
           close={close}
           isLive={isLive}
-          isOpen={isOpen}
           items={navItems}
           logout={firebase.logout}
           userProfile={userProfile} />

--- a/components/Banner.js
+++ b/components/Banner.js
@@ -132,10 +132,12 @@ const navItems = [
         <img
           alt={`${auth.displayName}'s avatar`}
           className="avatar"
+          role="presentation"
           src={auth.photoURL} />
       )
     },
     /* eslint-enable react/prop-types */
+    label: 'My Account',
     title: ({ auth }) => {
       if (isEmpty(auth)) {
         return 'Loading user data...'
@@ -243,13 +245,13 @@ const Banner = () => {
       <header role="banner">
         {/* eslint-disable jsx-a11y/tabindex-no-positive,jsx-a11y/no-noninteractive-element-to-interactive-role */}
         <label
+          aria-label={`${isOpen ? 'Collapse' : 'Expand'} Menu`}
           aria-pressed={isOpen ? 'true' : 'false'}
           className="button iconic primary"
           htmlFor="banner-control"
           onKeyUp={({ key }) => ['enter', ' '].includes(key.toLowerCase()) && setIsOpen(!isOpen)}
           role="button"
-          tabIndex="1"
-          title="Expand/Collapse Menu">
+          tabIndex="1">
           <span>
             <FontAwesomeIcon
               data-animate
@@ -264,8 +266,6 @@ const Banner = () => {
               data-animation-duration="0.2s"
               fixedWidth
               icon="times" />
-
-            <span className="screen-reader-only">Menu</span>
           </span>
         </label>
         {/* eslint-disable jsx-a11y/tabindex-no-positive,jsx-a11y/no-noninteractive-element-to-interactive-role */}

--- a/components/Banner.js
+++ b/components/Banner.js
@@ -145,6 +145,7 @@ const navItems = [
 
       return auth.displayName
     },
+    className: 'account-navigation',
     condition: ({ auth }) => !isEmpty(auth),
     subnav: [
       {
@@ -236,45 +237,10 @@ const Banner = () => {
 
   return (
     <>
-      <input
-        aria-label="Banner &amp; Navigation toggle"
-        checked={isOpen}
-        hidden
-        id="banner-control"
-        onChange={({ target: { checked } }) => setIsOpen(checked)}
-        type="checkbox" />
-
       <header
         aria-expanded={isOpen}
         hidden={isOpen}
         role="banner">
-        {/* eslint-disable jsx-a11y/tabindex-no-positive,jsx-a11y/no-noninteractive-element-to-interactive-role */}
-        <label
-          aria-label={`${isOpen ? 'Collapse' : 'Expand'} Menu`}
-          aria-pressed={isOpen ? 'true' : 'false'}
-          className="button iconic primary"
-          htmlFor="banner-control"
-          onKeyUp={({ key }) => ['enter', ' '].includes(key.toLowerCase()) && setIsOpen(!isOpen)}
-          role="button"
-          tabIndex="1">
-          <span>
-            <FontAwesomeIcon
-              data-animate
-              data-animation={`fade-${isOpen ? 'out' : 'in'}`}
-              data-animation-duration="0.2s"
-              fixedWidth
-              icon="bars" />
-
-            <FontAwesomeIcon
-              data-animate
-              data-animation={`fade-${isOpen ? 'in' : 'out'}`}
-              data-animation-duration="0.2s"
-              fixedWidth
-              icon="times" />
-          </span>
-        </label>
-        {/* eslint-disable jsx-a11y/tabindex-no-positive,jsx-a11y/no-noninteractive-element-to-interactive-role */}
-
         <h1 className="brand">&lt;trezy-who/&gt;</h1>
 
         <Nav
@@ -282,8 +248,10 @@ const Banner = () => {
           claims={claims}
           close={close}
           isLive={isLive}
+          isOpen={isOpen}
           items={navItems}
           logout={firebase.logout}
+          onToggle={() => setIsOpen(previousIsOpen => !previousIsOpen)}
           userProfile={userProfile} />
 
         <SocialNav isOpen={isOpen} />

--- a/components/Banner.js
+++ b/components/Banner.js
@@ -216,6 +216,8 @@ const Banner = () => {
     }
   }
 
+  const onToggle = () => setIsOpen(previousIsOpen => !previousIsOpen)
+
   useFirebaseConnect([
     { path: 'app-data' },
   ])
@@ -251,7 +253,7 @@ const Banner = () => {
           isOpen={isOpen}
           items={navItems}
           logout={firebase.logout}
-          onToggle={() => setIsOpen(previousIsOpen => !previousIsOpen)}
+          onToggle={(currentWidth <= RESIZE_BREAKPOINT) ? onToggle : null}
           userProfile={userProfile} />
 
         <SocialNav isOpen={isOpen} />

--- a/components/Button.js
+++ b/components/Button.js
@@ -1,4 +1,5 @@
 // Module imports
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import PropTypes from 'prop-types'
 import React from 'react'
 
@@ -7,28 +8,63 @@ import React from 'react'
 
 
 const Button = props => {
-  const { children } = props
+  const {
+    children,
+    icon,
+    iconPrefix,
+    type,
+  } = props
 
   const passableProps = { ...props }
   delete passableProps.children
+  delete passableProps.icon
+  delete passableProps.iconPrefix
+
+  let iconComponent = icon
+
+  if (typeof iconComponent === 'function') {
+    iconComponent = iconComponent(props)
+  }
+
+  if (typeof iconComponent === 'string') {
+    iconComponent = (
+      <FontAwesomeIcon
+        aria-hidden
+        fixedWidth
+        icon={[(iconPrefix || 'fas'), icon]} />
+    )
+  }
 
   return (
     // We're disabling the required type linter for the next line because the
     // `type` attribute is enforced by the proptypes
     // eslint-disable-next-line react/button-has-type
-    <button {...passableProps}>
+    <button
+      type={type}
+      {...passableProps}>
+      {iconComponent}
       <span>{children}</span>
     </button>
   )
 }
 
 Button.defaultProps = {
+  icon: null,
+  iconPrefix: 'fas',
   type: 'button',
 }
 
 Button.propTypes = {
   children: PropTypes.node.isRequired,
-  type: PropTypes.string,
+  icon: PropTypes.oneOfType([
+    PropTypes.node,
+    PropTypes.string,
+  ]),
+  iconPrefix: PropTypes.string,
+  type: PropTypes.oneOf([
+    'button',
+    'submit',
+  ]),
 }
 
 

--- a/components/Nav.js
+++ b/components/Nav.js
@@ -3,6 +3,7 @@ import React, {
   useRef,
   useState,
 } from 'react'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import PropTypes from 'prop-types'
 import uuid from 'uuid/v4'
 
@@ -11,6 +12,7 @@ import uuid from 'uuid/v4'
 
 
 // Component imports
+import Button from './Button'
 import NavLink from './NavLink'
 import Subnav from './Subnav'
 
@@ -28,7 +30,9 @@ const hoverIntentTimeout = 2000
 const Nav = props => {
   const {
     className,
+    isOpen,
     items,
+    onToggle,
   } = props
 
   const itemKeys = useRef({})
@@ -60,12 +64,38 @@ const Nav = props => {
   }
 
   return (
+    // We're specifically not adding key events to the main nav because a
+    // keyboard user won't expect the nav to suddenly close without their
+    // direct interaction.
     // eslint-disable-next-line jsx-a11y/mouse-events-have-key-events
     <nav
       className={className}
       onMouseOver={handleLeaveIntent}
       onMouseOut={handleEnterIntent}>
-      <ul>
+      {Boolean(onToggle) && (
+        <Button
+          aria-label={`${isOpen ? 'Collapse' : 'Expand'} main navigation`}
+          aria-pressed={isOpen}
+          className="button iconic primary"
+          id="banner-control"
+          onClick={onToggle}>
+          <FontAwesomeIcon
+            data-animate
+            data-animation={`fade-${isOpen ? 'out' : 'in'}`}
+            data-animation-duration="0.2s"
+            fixedWidth
+            icon="bars" />
+
+          <FontAwesomeIcon
+            data-animate
+            data-animation={`fade-${isOpen ? 'in' : 'out'}`}
+            data-animation-duration="0.2s"
+            fixedWidth
+            icon="times" />
+        </Button>
+      )}
+
+      <ul hidden={!isOpen}>
         {items.map((item, index) => {
           const {
             condition,
@@ -113,11 +143,15 @@ const Nav = props => {
 
 Nav.defaultProps = {
   className: '',
+  isOpen: true,
+  onToggle: null,
 }
 
 Nav.propTypes = {
   className: PropTypes.string,
+  isOpen: PropTypes.bool,
   items: PropTypes.array.isRequired,
+  onToggle: PropTypes.func,
 }
 
 

--- a/components/NavLink.js
+++ b/components/NavLink.js
@@ -1,10 +1,12 @@
 // Module imports
+import React, {
+  forwardRef,
+} from 'react'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { useRouter } from 'next/router'
 import classnames from 'classnames'
 import Link from 'next/link'
 import PropTypes from 'prop-types'
-import React from 'react'
 
 
 
@@ -18,11 +20,10 @@ import ExternalLink from './ExternalLink'
 
 
 
-const NavLink = props => {
+const NavLink = forwardRef((props, ref) => {
   const {
     extraProps,
     iconOnly,
-    isFocusable,
     onClick,
     target,
   } = props
@@ -39,6 +40,8 @@ const NavLink = props => {
   const icon = typeof props.icon === 'function' ? props.icon(passableProps) : props.icon
   const iconPrefix = typeof props.iconPrefix === 'function' ? props.iconPrefix(passableProps) : props.iconPrefix
   const title = typeof props.title === 'function' ? props.title(passableProps) : props.title
+
+  const isExternalLink = /https?:\/\//gui.test(href)
 
   let iconComponent = null
   let titleComponent = null
@@ -69,53 +72,52 @@ const NavLink = props => {
     }
   }
 
-  if (onClick) {
-    return (
-      <Button
-        {...extraProps}
-        className={classnames(className, { iconic: iconOnly })}
-        disabled={disabled}
-        onClick={event => onClick(event, passableProps)}
-        tabIndex={isFocusable ? null : '-1'}>
-        {iconComponent}
-
-        {titleComponent}
-      </Button>
-    )
-  }
-
-  if (/https?:\/\//gui.test(href)) {
-    return (
-      <ExternalLink
-        {...extraProps}
-        className={classnames(className, {
-          disabled,
-          iconic: iconOnly,
-        })}
-        href={href}
-        target={target}
-        tabIndex={isFocusable ? null : '-1'}>
-        {iconComponent}
-        {titleComponent}
-      </ExternalLink>
-    )
-  }
-
   return (
-    <Link href={href}>
-      <a
-        {...extraProps}
-        className={classnames(className, {
-          disabled,
-          iconic: iconOnly,
-        })}
-        tabIndex={isFocusable ? null : '-1'}> {/* eslint-disable-line jsx-a11y/no-noninteractive-tabindex */}
-        {iconComponent}
-        {titleComponent}
-      </a>
-    </Link>
+    <li>
+      {Boolean(onClick) && (
+        <Button
+          {...extraProps}
+          className={classnames(className, { iconic: iconOnly })}
+          disabled={disabled}
+          onClick={event => onClick(event, passableProps)}
+          ref={ref}>
+          {iconComponent}
+          {titleComponent}
+        </Button>
+      )}
+
+      {(!onClick && isExternalLink) && (
+        <ExternalLink
+          {...extraProps}
+          className={classnames(className, {
+            disabled,
+            iconic: iconOnly,
+          })}
+          href={href}
+          ref={ref}
+          target={target}>
+          {iconComponent}
+          {titleComponent}
+        </ExternalLink>
+      )}
+
+      {(!onClick && !isExternalLink) && (
+        <Link href={href}>
+          <a
+            {...extraProps}
+            className={classnames(className, {
+              disabled,
+              iconic: iconOnly,
+            })}
+            ref={ref}>
+            {iconComponent}
+            {titleComponent}
+          </a>
+        </Link>
+      )}
+    </li>
   )
-}
+})
 
 NavLink.defaultProps = {
   className: '',
@@ -126,7 +128,6 @@ NavLink.defaultProps = {
   iconComponent: null,
   iconOnly: false,
   iconPrefix: null,
-  isFocusable: true,
   onClick: null,
   target: null,
 }
@@ -157,10 +158,6 @@ NavLink.propTypes = {
   iconPrefix: PropTypes.oneOfType([
     PropTypes.func,
     PropTypes.string,
-  ]),
-  isFocusable: PropTypes.oneOfType([
-    PropTypes.bool,
-    PropTypes.func,
   ]),
   onClick: PropTypes.func,
   target: PropTypes.string,

--- a/components/NavLink.js
+++ b/components/NavLink.js
@@ -1,12 +1,10 @@
 // Module imports
-import React, {
-  forwardRef,
-} from 'react'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { useRouter } from 'next/router'
 import classnames from 'classnames'
 import Link from 'next/link'
 import PropTypes from 'prop-types'
+import React from 'react'
 
 
 
@@ -20,7 +18,7 @@ import ExternalLink from './ExternalLink'
 
 
 
-const NavLink = forwardRef((props, ref) => {
+const NavLink = props => {
   const {
     extraProps,
     iconOnly,
@@ -74,8 +72,7 @@ const NavLink = forwardRef((props, ref) => {
           className={classnames({ iconic: iconOnly })}
           disabled={disabled}
           icon={icon || iconComponent}
-          onClick={event => onClick(event, passableProps)}
-          ref={ref}>
+          onClick={event => onClick(event, passableProps)}>
           {titleComponent}
         </Button>
       )}
@@ -88,7 +85,6 @@ const NavLink = forwardRef((props, ref) => {
             iconic: iconOnly,
           })}
           href={href}
-          ref={ref}
           target={target}>
           {iconComponent}
           {Boolean(titleComponent) && (
@@ -104,8 +100,7 @@ const NavLink = forwardRef((props, ref) => {
             className={classnames({
               disabled,
               iconic: iconOnly,
-            })}
-            ref={ref}>
+            })}>
             {iconComponent}
             {Boolean(titleComponent) && (
               <span>{titleComponent}</span>
@@ -115,7 +110,7 @@ const NavLink = forwardRef((props, ref) => {
       )}
     </li>
   )
-})
+}
 
 NavLink.defaultProps = {
   className: '',

--- a/components/NavLink.js
+++ b/components/NavLink.js
@@ -52,7 +52,7 @@ const NavLink = forwardRef((props, ref) => {
     } else {
       iconComponent = props.iconComponent
     }
-  } else if (icon) {
+  } else if (icon && !onClick) {
     iconComponent = (
       <FontAwesomeIcon
         aria-hidden={!iconOnly}
@@ -63,25 +63,19 @@ const NavLink = forwardRef((props, ref) => {
   }
 
   if (!iconOnly) {
-    if (title instanceof Symbol) {
-      titleComponent = title
-    } else {
-      titleComponent = (
-        <span>{title}</span>
-      )
-    }
+    titleComponent = title
   }
 
   return (
-    <li>
+    <li className={className}>
       {Boolean(onClick) && (
         <Button
           {...extraProps}
-          className={classnames(className, { iconic: iconOnly })}
+          className={classnames({ iconic: iconOnly })}
           disabled={disabled}
+          icon={icon || iconComponent}
           onClick={event => onClick(event, passableProps)}
           ref={ref}>
-          {iconComponent}
           {titleComponent}
         </Button>
       )}
@@ -89,7 +83,7 @@ const NavLink = forwardRef((props, ref) => {
       {(!onClick && isExternalLink) && (
         <ExternalLink
           {...extraProps}
-          className={classnames(className, {
+          className={classnames({
             disabled,
             iconic: iconOnly,
           })}
@@ -97,7 +91,9 @@ const NavLink = forwardRef((props, ref) => {
           ref={ref}
           target={target}>
           {iconComponent}
-          {titleComponent}
+          {Boolean(titleComponent) && (
+            <span>{titleComponent}</span>
+          )}
         </ExternalLink>
       )}
 
@@ -105,13 +101,15 @@ const NavLink = forwardRef((props, ref) => {
         <Link href={href}>
           <a
             {...extraProps}
-            className={classnames(className, {
+            className={classnames({
               disabled,
               iconic: iconOnly,
             })}
             ref={ref}>
             {iconComponent}
-            {titleComponent}
+            {Boolean(titleComponent) && (
+              <span>{titleComponent}</span>
+            )}
           </a>
         </Link>
       )}

--- a/components/Subnav.js
+++ b/components/Subnav.js
@@ -1,7 +1,5 @@
 // Module imports
 import React, {
-  useEffect,
-  useRef,
   useState,
 } from 'react'
 import PropTypes from 'prop-types'
@@ -30,14 +28,7 @@ const Subnav = props => {
     subnav,
   } = props
 
-  const firstItemRef = useRef(null)
   const [subkeys] = useState({})
-
-  useEffect(() => {
-    if (isOpen) {
-      firstItemRef.current.focus()
-    }
-  }, [isOpen])
 
   if (condition && !condition(props)) {
     return null
@@ -112,10 +103,6 @@ const Subnav = props => {
             if (!subkey) {
               subkeys[index] = uuid()
               subkey = subkeys[index]
-            }
-
-            if (index === 0) {
-              itemProps.ref = firstItemRef
             }
 
             return (

--- a/components/Subnav.js
+++ b/components/Subnav.js
@@ -87,7 +87,7 @@ const Subnav = props => {
         </Button>
 
         <ul
-          aria-expanded={isOpen ? 'true' : 'false'}
+          aria-expanded={isOpen}
           hidden={!isOpen}>
           {subnav.map((item, index) => {
             if (item.condition && !item.condition(props)) {

--- a/components/Subnav.js
+++ b/components/Subnav.js
@@ -4,8 +4,6 @@ import React, {
   useRef,
   useState,
 } from 'react'
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import classnames from 'classnames'
 import PropTypes from 'prop-types'
 import uuid from 'uuid/v4'
 
@@ -53,28 +51,12 @@ const Subnav = props => {
 
   const className = typeof props.className === 'function' ? props.className(props) : props.className
   const icon = typeof props.icon === 'function' ? props.icon(props) : props.icon
+  const iconComponent = typeof props.iconComponent === 'function' ? props.iconComponent(props) : props.iconComponent
   const iconPrefix = typeof props.iconPrefix === 'function' ? props.iconPrefix(props) : props.iconPrefix
   const label = typeof props.label === 'function' ? props.label(props) : props.label
   const title = typeof props.title === 'function' ? props.title(props) : props.title
 
-  let iconComponent = null
   let titleComponent = null
-
-  if (props.iconComponent) {
-    if (typeof props.iconComponent === 'function') {
-      iconComponent = props.iconComponent(props)
-    } else {
-      iconComponent = props.iconComponent
-    }
-  } else if (icon) {
-    iconComponent = (
-      <FontAwesomeIcon
-        aria-hidden={!iconOnly}
-        fixedWidth
-        icon={[(iconPrefix || 'fas'), icon]}
-        title={title} />
-    )
-  }
 
   if (!iconOnly) {
     if (title instanceof Symbol) {
@@ -97,16 +79,19 @@ const Subnav = props => {
   }
 
   return (
-    <li key={title}>
+    <li
+      className={className}
+      key={title}>
       <nav
         aria-label={label || title}
-        className={classnames(className, 'subnav')}
+        className="subnav"
         key={id}>
         <Button
           aria-label={`${isOpen ? 'Close' : 'Expand'} ${label || title} navigation`}
-          className={classnames(className, 'iconic')}
+          aria-pressed={isOpen}
+          icon={icon || iconComponent}
+          iconPrefix={iconPrefix}
           onClick={onToggle}>
-          {iconComponent}
           {titleComponent}
         </Button>
 

--- a/scss/components/_banner-control.scss
+++ b/scss/components/_banner-control.scss
@@ -1,24 +1,25 @@
 #banner-control {
-  &:not(:checked) ~ [role=banner] .subnav {
-    max-height: 0;
-    opacity: 0;
+  font-size: 2em;
+  left: calc(100% + var(--gutter));
+  line-height: 1;
+  opacity: 1;
+  position: absolute;
+  top: 0;
+  transition-duration: 0.2s;
+  transition-property: opacity;
+  width: auto;
+
+  svg:not(:first-child) {
+    left: 50%;
+    position: absolute;
+    top: 50%;
+    transform: translate(-50%, -50%);
   }
 
-  @media (max-width: 1300px) {
-    &:checked {
-      ~ [role=banner] {
-        transform: translateX(0);
-      }
-
-      ~ main {
-        pointer-events: none;
-        transform: scale(0.8) translateY(20vh);
-
-        &:after {
-          pointer-events: initial;
-          opacity: 0.4;
-        }
-      }
+  @media (min-width: 1300px) {
+    &, &:focus {
+      opacity: 0;
+      pointer-events: none;
     }
   }
 }

--- a/scss/components/_banner.scss
+++ b/scss/components/_banner.scss
@@ -13,53 +13,17 @@
     background-color,
     transform;
 
-  %anchor-hover-styles {
-    background-color: var(--brand-primary);
-    color: var(--inverted-text-color);
-    outline: none;
-    width: calc(100%);
-
-    @media (prefers-color-scheme: dark) {
-      color: var(--text-color);
-    }
-  }
-
-  [for='banner-control'] {
-    font-size: 2em;
-    left: calc(100% + var(--gutter));
-    opacity: 1;
-    position: absolute;
-    top: 0;
-    transition-duration: 0.2s;
-    transition-property: opacity;
-    width: auto;
-
-    svg:not(:first-child) {
-      left: 50%;
-      position: absolute;
-      top: 50%;
-      transform: translate(-50%, -50%);
-    }
-
-    @media (min-width: 1300px) {
-      &, &:focus {
-        opacity: 0;
-        pointer-events: none;
-      }
-    }
-  }
-
   .brand,
   nav {
     background-color: var(--background-color);
     margin-bottom: 0;
   }
 
-  nav {
+  > nav {
     overflow-y: auto;
 
     a,
-    button {
+    button:not(#banner-control) {
       align-items: center;
       border: none;
       color: var(--text-color);
@@ -79,8 +43,14 @@
 
       &:focus,
       &:hover {
-        @extend %anchor-hover-styles;
-        z-index: 1;
+        background-color: var(--brand-primary);
+        color: var(--inverted-text-color);
+        outline: none;
+        width: calc(100%);
+
+        @media (prefers-color-scheme: dark) {
+          color: var(--text-color);
+        }
       }
 
       [data-icon],
@@ -98,11 +68,10 @@
       }
     }
 
-    button {
+    button:not(#banner-control) {
       overflow: hidden;
 
-      &:before,
-      &:after {
+      &:before {
         display: none;
       }
     }
@@ -111,14 +80,6 @@
       display: flex;
       flex-direction: column;
       position: relative;
-
-      &:focus,
-      &:hover {
-        > a,
-        > label {
-          @extend %anchor-hover-styles;
-        }
-      }
     }
   }
 
@@ -127,7 +88,7 @@
   }
 
   .subnav {
-   > ul {
+    > ul {
       background-color: var(--light-grey);
       color: var(--background-color);
       overflow: hidden;
@@ -135,22 +96,20 @@
       transition-property: max-height, opacity;
     }
 
-    > button {
-      &:after {
-        border-color: transparent;
-        border-style: solid;
-        border-width: 0.5rem;
-        border-bottom-width: 0;
-        border-top-color: currentColor;
-        content: '';
-        display: inline;
-        margin-left: auto;
-        opacity: 1;
-        position: initial;
-        transform: rotate(0);
-        transition-duration: 0.2s;
-        transition-property: border-top-color, transform;
-      }
+    > button:after {
+      border-color: transparent;
+      border-style: solid;
+      border-width: 0.5rem;
+      border-bottom-width: 0;
+      border-top-color: currentColor;
+      content: '';
+      display: inline;
+      margin-left: auto;
+      opacity: 1;
+      position: initial;
+      transform: rotate(0);
+      transition-duration: 0.2s;
+      transition-property: border-top-color, transform;
     }
 
     > ul {
@@ -162,23 +121,6 @@
       &[aria-expanded=true] {
         max-height: 100vh !important;
         opacity: 1 !important;
-      }
-    }
-  }
-
-  [name='subnav']:checked {
-    ~ ul.subnav {
-      max-height: 100vh !important;
-      opacity: 1 !important;
-      pointer-events: initial;
-    }
-
-    ~ a,
-    ~ label {
-      @extend %anchor-hover-styles;
-
-      &:after {
-        transform: rotate(-180deg);
       }
     }
   }
@@ -201,13 +143,27 @@
     background-color: var(--background-color);
     position: fixed;
     transform: translateX(calc(-100% - var(--gutter)));
+    will-change: transform;
     z-index: 1;
+
+    &[aria-expanded=true] {
+      transform: translateX(0);
+
+      ~ main {
+        pointer-events: none;
+        transform: scale(0.8) translateY(20vh);
+
+        &:after {
+          pointer-events: initial;
+          opacity: 0.4;
+        }
+      }
+    }
   }
 
   @media (min-width: 1300px) {
     position: sticky;
     top: var(--gutter);
-    will-change: transform;
     z-index: 1;
   }
 }

--- a/scss/components/_banner.scss
+++ b/scss/components/_banner.scss
@@ -59,8 +59,7 @@
     overflow-y: auto;
 
     a,
-    button,
-    label {
+    button {
       align-items: center;
       border: none;
       color: var(--text-color);
@@ -99,20 +98,12 @@
       }
     }
 
-    label {
+    button {
+      overflow: hidden;
+
+      &:before,
       &:after {
-        border-color: transparent;
-        border-style: solid;
-        border-width: 0.5rem;
-        border-bottom-width: 0;
-        border-top-color: currentColor;
-        content: '';
-        height: 0;
-        margin-left: auto;
-        transform: rotate(0);
-        transition-duration: 0.2s;
-        transition-property: border-top-color, transform;
-        width: 0;
+        display: none;
       }
     }
 
@@ -136,14 +127,43 @@
   }
 
   .subnav {
-    background-color: hsla(var(--text-color-h), var(--text-color-s), var(--text-color-l), 0.1);
-    color: var(--background-color);
-    max-height: 0;
-    opacity: 0;
-    overflow: hidden;
-    pointer-events: none;
-    transition-duration: 0.2s;
-    transition-property: max-height, opacity;
+   > ul {
+      background-color: var(--light-grey);
+      color: var(--background-color);
+      overflow: hidden;
+      transition-duration: 0.2s;
+      transition-property: max-height, opacity;
+    }
+
+    > button {
+      &:after {
+        border-color: transparent;
+        border-style: solid;
+        border-width: 0.5rem;
+        border-bottom-width: 0;
+        border-top-color: currentColor;
+        content: '';
+        display: inline;
+        margin-left: auto;
+        opacity: 1;
+        position: initial;
+        transform: rotate(0);
+        transition-duration: 0.2s;
+        transition-property: border-top-color, transform;
+      }
+    }
+
+    > ul {
+      &[aria-expanded=false] {
+        max-height: 0;
+        opacity: 0;
+      }
+
+      &[aria-expanded=true] {
+        max-height: 100vh !important;
+        opacity: 1 !important;
+      }
+    }
   }
 
   [name='subnav']:checked {

--- a/scss/core/_root.scss
+++ b/scss/core/_root.scss
@@ -42,7 +42,6 @@ body {
   transition-duration: 0.2s;
   transition-property: font-size;
 
-  .next-wrapper,
   #__next {
     height: 100%;
   }


### PR DESCRIPTION
## Description

This is a major refactor to make the `<Banner>` component more accessible. When I originally designed the component, I used a lot of hacky solutions to make something that was *sort of* accessible. I'm coming at it now with a better grasp on what WAI-ARIA provides and how screen readers actually work.

## Notable changes

* Refactored the way the banner decides when to open/close with screen size changes
* Focus is automatically sent to the first item of a subnav when the subnav is opened
* Subnav buttons have more valuable labels for screen readers
* Subnav links now use `hidden` instead of `tabindex` to prevent focus when the subnav is closed
* The `<Banner>` no longer uses checkboxes to show/hide components